### PR TITLE
Kubeadm - Fixes + Custom Cluster Name Support

### DIFF
--- a/kubeadm/ansible/bootstrap_etcd_master.yml
+++ b/kubeadm/ansible/bootstrap_etcd_master.yml
@@ -13,7 +13,7 @@
     become: true
 
   - name: move certs
-    shell: mv ./ca.pem ./kubernetes.pem ./kubernetes-key.pem /etc/etcd
+    shell: mv ./ca.pem ./{{cluster_name}}.pem ./{{cluster_name}}-key.pem /etc/etcd
     become: true
     ignore_errors: yes
 
@@ -46,10 +46,10 @@
         [Service]
         ExecStart=/usr/local/bin/etcd \
           --name {{name}} \
-          --cert-file=/etc/etcd/kubernetes.pem \
-          --key-file=/etc/etcd/kubernetes-key.pem \
-          --peer-cert-file=/etc/etcd/kubernetes.pem \
-          --peer-key-file=/etc/etcd/kubernetes-key.pem \
+          --cert-file=/etc/etcd/{{cluster_name}}.pem \
+          --key-file=/etc/etcd/{{cluster_name}}-key.pem \
+          --peer-cert-file=/etc/etcd/{{cluster_name}}.pem \
+          --peer-key-file=/etc/etcd/{{cluster_name}}-key.pem \
           --trusted-ca-file=/etc/etcd/ca.pem \
           --peer-trusted-ca-file=/etc/etcd/ca.pem \
           --peer-client-cert-auth \

--- a/kubeadm/ansible/generate_certs.yml
+++ b/kubeadm/ansible/generate_certs.yml
@@ -45,7 +45,7 @@
       dest: "./{{cluster_name}}-csr.json"
       content: |
         {
-          "CN": "{{cluster_name}}",
+          "CN": "kubernetes",
           "key": {
             "algo": "rsa",
             "size": 2048
@@ -98,10 +98,10 @@
 
   - name: Copy kubernetes.pem
     copy:
-      src: ./kubernetes.pem
-      dest: ~/kubernetes.pem
+      src: ./{{cluster_name}}.pem
+      dest: ~/{{cluster_name}}.pem
 
   - name: Copy kubernetes-key.pem
     copy:
-      src: ./kubernetes-key.pem
-      dest: ~/kubernetes-key.pem
+      src: ./{{cluster_name}}-key.pem
+      dest: ~/{{cluster_name}}-key.pem

--- a/kubeadm/ansible/group_vars/hosts.yml
+++ b/kubeadm/ansible/group_vars/hosts.yml
@@ -17,35 +17,35 @@ all:
             mainMaster:
               hosts:
                 master0:
-                  ansible_host: 172.26.22.120
-                  name: 172.26.22.120
-                  initial_advertise_peer_url: https://172.26.22.120:2380
-                  listen_peer_url: https://172.26.22.120:2380
+                  ansible_host: "{{hostnames[0]}}"
+                  name: "{{hostnames[0]}}"
+                  initial_advertise_peer_url: https://{{hostnames[0]}}:2380
+                  listen_peer_url: https://{{hostnames[0]}}:2380
                   listen_client_urls:
-                    - https://172.26.22.120:2379
+                    - https://{{hostnames[0]}}:2379
                     - http://127.0.0.1:2379
-                  advertise_client_url: https://172.26.22.120:2379
+                  advertise_client_url: https://{{hostnames[0]}}:2379
             # SECONDARY MASTERS
             secondaryMasters:
               hosts:
                 master1:
-                  ansible_host: 172.26.22.121
-                  name: 172.26.22.121
-                  initial_advertise_peer_url: https://172.26.22.121:2380
-                  listen_peer_url: https://172.26.22.121:2380
+                  ansible_host: "{{hostnames[1]}}"
+                  name: "{{hostnames[1]}}"
+                  initial_advertise_peer_url: https://{{hostnames[1]}}:2380
+                  listen_peer_url: https://{{hostnames[1]}}:2380
                   listen_client_urls:
-                    - https://172.26.22.121:2379
+                    - https://{{hostnames[1]}}:2379
                     - http://127.0.0.1:2379
-                  advertise_client_url: https://172.26.22.121:2379
+                  advertise_client_url: https://{{hostnames[1]}}:2379
                 master2:
-                  ansible_host: 172.26.22.122
-                  name: 172.26.22.122
-                  initial_advertise_peer_url: https://172.26.22.122:2380
-                  listen_peer_url: https://172.26.22.122:2380
+                  ansible_host: "{{hostnames[2]}}"
+                  name: "{{hostnames[2]}}"
+                  initial_advertise_peer_url: https://{{hostnames[2]}}:2380
+                  listen_peer_url: https://{{hostnames[2]}}:2380
                   listen_client_urls:
-                    - https://172.26.22.122:2379
+                    - https://{{hostnames[2]}}:2379
                     - http://127.0.0.1:2379
-                  advertise_client_url: https://172.26.22.122:2379
+                  advertise_client_url: https://{{hostnames[2]}}:2379
           # VARIABLES FOR MASTER NODES
           vars:
             pod_subnet: "100.96.0.0/11"
@@ -58,9 +58,9 @@ all:
               name: worker0
       # VARIABLES FOR ALL NODES
       vars:
-        master0_url: 172.26.22.120
-        master1_url: 172.26.22.121
-        master2_url: 172.26.22.122
+        master0_url: "{{hostnames[0]}}"
+        master1_url: "{{hostnames[1]}}"
+        master2_url: "{{hostnames[2]}}"
         master_api_port: 6443
         ansible_connection: ssh
   # VARIABLES FOR ALL HOSTS

--- a/kubeadm/ansible/init_k8s.yml
+++ b/kubeadm/ansible/init_k8s.yml
@@ -5,7 +5,7 @@
     become: true
 
   - name: copy kubeconfig
-    shell: cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+    shell: cp /etc/kubernetes/admin.conf $HOME/.kube/config
     become: true
 
   - name: set owner

--- a/kubeadm/ansible/init_k8s.yml
+++ b/kubeadm/ansible/init_k8s.yml
@@ -16,16 +16,20 @@
   tasks:
   - name: Apply overlay network
     shell: kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"    
+    become: true
 
   - name: Apply storage
     shell: kubectl apply -f https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/addons/storage-class/vsphere/default.yaml
+    become: true
 
   - name: Enable admin RBAC for the default namespace 
     shell: kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
+    become: true
 
   - name: Create token for workers
     shell: kubeadm token create --config=cluster-config.yaml
     register: worker_token
+    become: true
 
   - name: Create worker file
     copy:

--- a/kubeadm/ansible/init_k8s.yml
+++ b/kubeadm/ansible/init_k8s.yml
@@ -43,8 +43,6 @@
         kind: JoinConfiguration
         nodeRegistration:
           criSocket: /var/run/dockershim.sock
-          kubeletExtraArgs:
-            cloud-provider: "vsphere"
         tlsBootstrapToken: {{worker_token.stdout}}
         token: {{worker_token.stdout}}
 

--- a/kubeadm/ansible/init_k8s.yml
+++ b/kubeadm/ansible/init_k8s.yml
@@ -18,10 +18,6 @@
     shell: kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"    
     become: true
 
-  - name: Apply storage
-    shell: kubectl apply -f https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/addons/storage-class/vsphere/default.yaml
-    become: true
-
   - name: Enable admin RBAC for the default namespace 
     shell: kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
     become: true

--- a/kubeadm/ansible/reset_cluster_node.yml
+++ b/kubeadm/ansible/reset_cluster_node.yml
@@ -34,12 +34,6 @@
       name: kubeadm
       state: absent
     become: true
-  - name: Copying iptables
-    shell: cp /etc/sysconfig/iptables ./iptables.bac
-    become: true
-  - name: Copying iptables.save
-    shell: cp /etc/sysconfig/iptables.save ./iptables.save.bac
-    become: true
   - name: Removing all iptable rules
     shell: |
       iptables -F

--- a/kubeadm/ansible/templates/cluster-config.j2
+++ b/kubeadm/ansible/templates/cluster-config.j2
@@ -1,6 +1,7 @@
 apiVersion: kubeadm.k8s.io/v1alpha3
 kind: ClusterConfiguration
 kubernetesVersion: {{kubernetes_version}}
+clusterName: {{cluster_name}}
 apiServerCertSANs: 
 {% for number in range(hostnames | length) %}
   - {{hostnames[number]}}
@@ -13,8 +14,8 @@ etcd:
     - https://{{master1_url}}:2379
     - https://{{master2_url}}:2379
     caFile: /etc/etcd/ca.pem
-    certFile: /etc/etcd/kubernetes.pem
-    keyFile: /etc/etcd/kubernetes-key.pem
+    certFile: /etc/etcd/{{cluster_name}}.pem
+    keyFile: /etc/etcd/{{cluster_name}}-key.pem
 networking:
   podSubnet: "{{pod_subnet}}"
 apiServerExtraArgs:

--- a/kubeadm/terraform/output.tf
+++ b/kubeadm/terraform/output.tf
@@ -6,7 +6,6 @@ output "bastion" {
   value = "${join("\n", aws_instance.bastion-server.*.public_ip)}"
 }
 
-
 output "workers" {
   value = "${join("\n", aws_instance.k8s-worker.*.private_ip)}"
 }

--- a/kubeadm/terraform/variables.tf
+++ b/kubeadm/terraform/variables.tf
@@ -88,10 +88,12 @@ variable "aws_kube_worker_size" {
 */
 variable "aws_elb_api_port" {
   description = "Port for AWS ELB"
+  default     = 6443
 }
 
 variable "k8s_secure_api_port" {
   description = "Secure Port of K8S API Server"
+  default     = 6443
 }
 
 variable "default_tags" {

--- a/kubeadm/terraform/variables.tf
+++ b/kubeadm/terraform/variables.tf
@@ -14,7 +14,7 @@ variable "AWS_DEFAULT_REGION" {
 
 variable "aws_cluster_name" {
   description = "Name of AWS Cluster: Kubeadm defaults to 'kubernetes'"
-  default = "kubernetes"
+  default     = "kubernetes"
 }
 
 data "aws_ami" "distro" {
@@ -23,6 +23,7 @@ data "aws_ami" "distro" {
   filter {
     name   = "name"
     values = ["RHEL-7.5_HVM_GA-*"]
+
     #values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
   }
 
@@ -96,8 +97,9 @@ variable "k8s_secure_api_port" {
 variable "default_tags" {
   description = "Default tags for all resources"
   type        = "map"
-  default     = { 
-                  Deployment = "Polaris"
-                  Git = "https://github.com/synthesis-labs/polaris"
-                }
+
+  default = {
+    Deployment = "Polaris"
+    Git        = "https://github.com/synthesis-labs/polaris"
+  }
 }


### PR DESCRIPTION
Various fixes + added support for custom cluster names.

Fixes include:

1. Replace hard coded master IPs with array reference.
2. Removed remaining VSphere components
3. Fixed copy prompt in cluster instantiation if the config file already exists.